### PR TITLE
Authorized group option

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ app.post('/authenticate', function (req, res) {
 					user_name: user.uid,
 					full_name: user.displayName,
 					mail: user.mail,
-					users_authorized_groups: usersGroupsForPayload
+					user_authorized_groups: usersGroupsForPayload
 				}, app.get('jwtTokenSecret'));
 
 		                if (settings.debug) {
@@ -154,7 +154,7 @@ app.post('/verify', function (req, res) {
                                     console.log ('Now: ' + new Date(Date.now()).toLocaleString());
                                 }
 			} else if (req.body.authorized_groups != undefined) {
-				if (decoded.hasOwnProperty("users_authorized_groups") && userInAuthorizedGroups(decoded.users_authorized_groups, req.body.authorized_groups)) {
+				if (decoded.hasOwnProperty("user_authorized_groups") && userInAuthorizedGroups(decoded.user_authorized_groups, req.body.authorized_groups)) {
 					res.json(decoded);
 					if (settings.debug) console.log('< verify succeeded for user in authorized_groups');
 				} else {

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ app.post('/authenticate', function (req, res) {
 		authenticate(req.body.username, req.body.password, req.body.authorized_group)
 			.then(function(user) {
 				if (req.body.authorized_group != undefined) {
-					if (settings.debug) console.log("Only authenticating members of " + req.body.authorized_group);
+					if (settings.debug) console.log("authorized_group specified: " + req.body.authorized_group);
 					if (!userInAuthorizedGroup(user.memberOf, req.body.authorized_group)) {
 						throw "User not in authorized_group";
 					}
@@ -101,7 +101,7 @@ app.post('/authenticate', function (req, res) {
 				}, app.get('jwtTokenSecret'));
 
 		                if (settings.debug) {
-			            console.log( 'Authentication succeeded ' + req.body.username );
+			            console.log( 'Authentication succeeded for ' + req.body.username );
 		                }
 				res.json({token: token, full_name: user.displayName, mail: user.mail});
 			})

--- a/index.js
+++ b/index.js
@@ -176,17 +176,17 @@ app.post('/verify', function (req, res) {
 	}
 });
 
-let userInAuthorizedGroups = function(usersGroups, authorized_groups) {
-	if (!Array.isArray(usersGroups)) usersGroups = [ usersGroups ];
+let userInAuthorizedGroups = function(userGroups, authorized_groups) {
+	if (!Array.isArray(userGroups)) userGroups = [ userGroups ];
 	if (!Array.isArray(authorized_groups)) authorized_groups = [ authorized_groups ];
-	if (settings.debug) console.log({msg: 'Checking groups in userInAuthorizedGroups', usersGroups: usersGroups, authorized_groups: authorized_groups});
-	return usersGroups.some(group => authorized_groups.includes(group));
+	if (settings.debug) console.log({msg: 'Checking groups in userInAuthorizedGroups', userGroups: userGroups, authorized_groups: authorized_groups});
+	return userGroups.some(group => authorized_groups.includes(group));
 }
 
-let userGroupAuthGroupIntersection = function(usersGroups, authorized_groups) {
-	if (!Array.isArray(usersGroups)) usersGroups = [ usersGroups ];
+let userGroupAuthGroupIntersection = function(userGroups, authorized_groups) {
+	if (!Array.isArray(userGroups)) userGroups = [ userGroups ];
 	if (!Array.isArray(authorized_groups)) authorized_groups = [ authorized_groups ];
-	return usersGroups.filter(group => authorized_groups.includes(group));
+	return userGroups.filter(group => authorized_groups.includes(group));
 }
 
 

--- a/index.js
+++ b/index.js
@@ -91,13 +91,14 @@ app.post('/authenticate', function (req, res) {
 					}
 				}
 				var expires = moment().add(settings.jwt.timeout, settings.jwt.timeout_units).valueOf();
+				let usersGroupsForPayload = userGroupAuthGroupIntersection(user.memberOf, req.body.authorized_groups);
 				var token = jwt.encode({
 					exp: expires,
 					aud: settings.jwt.clientid,
 					user_name: user.uid,
 					full_name: user.displayName,
 					mail: user.mail,
-					authorized_groups: req.body.authorized_groups
+					authorized_groups: usersGroupsForPayload
 				}, app.get('jwtTokenSecret'));
 
 		                if (settings.debug) {
@@ -177,6 +178,11 @@ let userInAuthorizedGroups = function(usersGroups, authorized_groups) {
 	if (!Array.isArray(usersGroups)) usersGroups = [ usersGroups ];
 	if (!Array.isArray(authorized_groups)) authorized_groups = [ authorized_groups ];
 	return usersGroups.some(group => authorized_groups.includes(group));
+}
+
+let userGroupAuthGroupIntersection = function(usersGroups, authorized_groups) {
+	if (!Array.isArray(authorized_groups)) authorized_groups = [ authorized_groups ];
+	return usersGroups.filter(group => authorized_groups.includes(group));
 }
 
 

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ app.post('/authenticate', function (req, res) {
 					user_name: user.uid,
 					full_name: user.displayName,
 					mail: user.mail,
-					authorized_groups: usersGroupsForPayload
+					users_authorized_groups: usersGroupsForPayload
 				}, app.get('jwtTokenSecret'));
 
 		                if (settings.debug) {
@@ -154,7 +154,7 @@ app.post('/verify', function (req, res) {
                                     console.log ('Now: ' + new Date(Date.now()).toLocaleString());
                                 }
 			} else if (req.body.authorized_groups != undefined) {
-				if (decoded.hasOwnProperty("authorized_groups") && userInAuthorizedGroups(req.body.authorized_groups, decoded.authorized_groups)) {
+				if (decoded.hasOwnProperty("users_authorized_groups") && userInAuthorizedGroups(decoded.users_authorized_groups, req.body.authorized_groups)) {
 					res.json(decoded);
 					if (settings.debug) console.log('< verify succeeded for user in authorized_groups');
 				} else {
@@ -183,6 +183,7 @@ let userInAuthorizedGroups = function(usersGroups, authorized_groups) {
 }
 
 let userGroupAuthGroupIntersection = function(usersGroups, authorized_groups) {
+	if (!Array.isArray(usersGroups)) usersGroups = [ usersGroups ];
 	if (!Array.isArray(authorized_groups)) authorized_groups = [ authorized_groups ];
 	return usersGroups.filter(group => authorized_groups.includes(group));
 }

--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ app.post('/authenticate', function (req, res) {
 				}, app.get('jwtTokenSecret'));
 
 		                if (settings.debug) {
+			            console.log({msg: 'Added these user groups to token payload', usersGroupsForPayload: usersGroupsForPayload});
 			            console.log( 'Authentication succeeded for ' + req.body.username );
 		                }
 				res.json({token: token, full_name: user.displayName, mail: user.mail});
@@ -177,6 +178,7 @@ app.post('/verify', function (req, res) {
 let userInAuthorizedGroups = function(usersGroups, authorized_groups) {
 	if (!Array.isArray(usersGroups)) usersGroups = [ usersGroups ];
 	if (!Array.isArray(authorized_groups)) authorized_groups = [ authorized_groups ];
+	if (settings.debug) console.log({msg: 'Checking groups in userInAuthorizedGroups', usersGroups: usersGroups, authorized_groups: authorized_groups});
 	return usersGroups.some(group => authorized_groups.includes(group));
 }
 

--- a/index.js
+++ b/index.js
@@ -174,6 +174,8 @@ app.post('/verify', function (req, res) {
 });
 
 let userInAuthorizedGroups = function(usersGroups, authorized_groups) {
+	if (!Array.isArray(usersGroups)) usersGroups = [ usersGroups ];
+	if (!Array.isArray(authorized_groups)) authorized_groups = [ authorized_groups ];
 	return usersGroups.some(group => authorized_groups.includes(group));
 }
 

--- a/index.js
+++ b/index.js
@@ -151,6 +151,14 @@ app.post('/verify', function (req, res) {
                                     console.log ('Expiry date: ' + new Date(decoded.exp).toLocaleString());
                                     console.log ('Now: ' + new Date(Date.now()).toLocaleString());
                                 }
+			} else if (req.body.authorized_group != undefined) {
+				if (decoded.hasOwnProperty("authorized_group") && decoded.authorized_group === req.body.authorized_group) {
+					res.json(decoded);
+					if (settings.debug) console.log('< verify succeeded for user in authorized_group');
+				} else {
+					res.status(401).send({ error: 'User not in authorized_group' });
+					if (settings.debug) console.error('< verify failed; user not in authorized_group');
+				}
 			} else {
 				res.json(decoded);
 				if (settings.debug) console.log ('< verify succeeded');

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var settings = require('./config/config.json');
 
 if (settings.debug) {
-    console.log( 'Settings: ' + JSON.stringify( settings ) );
+    console.log( 'Settings: ' + JSON.stringify( settings, null, 5 ) );
 }
 
 var bodyParser = require('body-parser');
@@ -84,6 +84,7 @@ app.post('/authenticate', function (req, res) {
 		}
 		authenticate(req.body.username, req.body.password, req.body.authorized_groups)
 			.then(function(user) {
+				if (settings.debug) console.log({user: user});
 				if (req.body.authorized_groups != undefined) {
 					if (settings.debug) console.log("authorized_groups specified: " + req.body.authorized_groups);
 					if (!userInAuthorizedGroups(user.memberOf, req.body.authorized_groups)) {

--- a/index.js
+++ b/index.js
@@ -88,7 +88,6 @@ app.post('/authenticate', function (req, res) {
 				if (req.body.authorized_groups != undefined) {
 					if (settings.debug) console.log("authorized_groups specified: " + req.body.authorized_groups);
 					if (!user.hasOwnProperty("memberOf")) {
-						console.log("Groups authorization requested, but server not configured to provide memberOf information");
 						throw "Server not configured for authorized_group verification";
 					}
 					var userGroupsForPayload = userGroupAuthGroupIntersection(user.memberOf, req.body.authorized_groups);
@@ -122,9 +121,9 @@ app.post('/authenticate', function (req, res) {
 				if (err.name === 'InvalidCredentialsError' || (typeof err === 'string' && err.match(/no such user/i)) ) {
 					res.status(401).send({ error: 'Wrong user or password'});
 				} else if (err === "Server not configured for authorized_group verification") {
-					res.status(501).send({ error: "Server not configured for authorized_group verification" });
+					res.status(401).send({ error: "User is not authorized." });
 				} else if (err === "User not in authorized_groups") {
-					res.status(401).send({ error: "User not in authorized_groups" });
+					res.status(401).send({ error: "User is not authorized." });
 				} else {
 					// ldapauth-fork or underlying connections may be in an unusable state.
 					// Reconnect option does re-establish the connections, but will not

--- a/index.js
+++ b/index.js
@@ -87,23 +87,23 @@ app.post('/authenticate', function (req, res) {
 				if (settings.debug) console.log({user: user});
 				if (req.body.authorized_groups != undefined) {
 					if (settings.debug) console.log("authorized_groups specified: " + req.body.authorized_groups);
+					var userGroupsForPayload = userGroupAuthGroupIntersection(user.memberOf, req.body.authorized_groups);
 					if (!userInAuthorizedGroups(user.memberOf, req.body.authorized_groups)) {
 						throw "User not in authorized_groups";
 					}
+					if (settings.debug) console.log({userGroupsForPayload: userGroupsForPayload});
 				}
 				var expires = moment().add(settings.jwt.timeout, settings.jwt.timeout_units).valueOf();
-				let usersGroupsForPayload = userGroupAuthGroupIntersection(user.memberOf, req.body.authorized_groups);
 				var token = jwt.encode({
 					exp: expires,
 					aud: settings.jwt.clientid,
 					user_name: user.uid,
 					full_name: user.displayName,
 					mail: user.mail,
-					user_authorized_groups: usersGroupsForPayload
+					user_authorized_groups: userGroupsForPayload
 				}, app.get('jwtTokenSecret'));
 
 		                if (settings.debug) {
-			            console.log({msg: 'Added these user groups to token payload', usersGroupsForPayload: usersGroupsForPayload});
 			            console.log( 'Authentication succeeded for ' + req.body.username );
 		                }
 				res.json({token: token, full_name: user.displayName, mail: user.mail});

--- a/index.js
+++ b/index.js
@@ -87,6 +87,10 @@ app.post('/authenticate', function (req, res) {
 				if (settings.debug) console.log({user: user});
 				if (req.body.authorized_groups != undefined) {
 					if (settings.debug) console.log("authorized_groups specified: " + req.body.authorized_groups);
+					if (!user.hasOwnProperty("memberOf")) {
+						console.log("Groups authorization requested, but server not configured to provide memberOf information");
+						throw "Server not configured for authorized_group verification";
+					}
 					var userGroupsForPayload = userGroupAuthGroupIntersection(user.memberOf, req.body.authorized_groups);
 					if (!userInAuthorizedGroups(user.memberOf, req.body.authorized_groups)) {
 						throw "User not in authorized_groups";
@@ -117,6 +121,8 @@ app.post('/authenticate', function (req, res) {
 
 				if (err.name === 'InvalidCredentialsError' || (typeof err === 'string' && err.match(/no such user/i)) ) {
 					res.status(401).send({ error: 'Wrong user or password'});
+				} else if (err === "Server not configured for authorized_group verification") {
+					res.status(501).send({ error: "Server not configured for authorized_group verification" });
 				} else if (err === "User not in authorized_groups") {
 					res.status(401).send({ error: "User not in authorized_groups" });
 				} else {

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ app.post('/verify', function (req, res) {
 					res.json(decoded);
 					if (settings.debug) console.log('< verify succeeded for user in authorized_groups');
 				} else {
-					res.status(401).send({ error: 'User not in authorized_groups' });
+					res.status(401).send({ error: 'Token not authorized for specified groups' });
 					if (settings.debug) console.error('< verify failed; user not in authorized_groups');
 				}
 			} else {

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ app.post('/verify', function (req, res) {
                                     console.log ('Now: ' + new Date(Date.now()).toLocaleString());
                                 }
 			} else if (req.body.authorized_group != undefined) {
-				if (decoded.hasOwnProperty("authorized_group") && decoded.authorized_group === req.body.authorized_group) {
+				if (decoded.hasOwnProperty("authorized_group") && userInAuthorizedGroup(req.body.authorized_group, decoded.authorized_group)) {
 					res.json(decoded);
 					if (settings.debug) console.log('< verify succeeded for user in authorized_group');
 				} else {
@@ -174,11 +174,7 @@ app.post('/verify', function (req, res) {
 });
 
 let userInAuthorizedGroup = function(users_memberOf, authorized_group) {
-	if (users_memberOf.includes(authorized_group)) {
-		return true;
-	} else {
-		return false;
-	}
+	return users_memberOf.some(group => authorized_group.includes(group));
 }
 
 

--- a/setconfig
+++ b/setconfig
@@ -113,7 +113,7 @@ env | awk '
         }
     }'
 echo '    "enabled": true,'
-echo '    "searchAttributes": ["mail", "displayName", "memberOf"]'
+echo '    "searchAttributes": ["mail", "displayName", "memberOf", "uid"]'
 if [ "X${CLIENT_ID}" = X ] ; then
     echo '  }'
 else

--- a/setconfig
+++ b/setconfig
@@ -113,7 +113,7 @@ env | awk '
         }
     }'
 echo '    "enabled": true,'
-echo '    "searchAttributes": ["mail", "displayName", "memberOf", "uid"]'
+echo '    "searchAttributes": ["mail", "displayName", "memberOf"]'
 if [ "X${CLIENT_ID}" = X ] ; then
     echo '  }'
 else

--- a/setconfig
+++ b/setconfig
@@ -92,14 +92,12 @@ env | awk '
         quote["queueTimeout"] = "";
         quote["queueDisable"] = "";
 
-        # Override quote for list/array options also.
-        # Note: Docker does not send array-type environment variables as arrays. For this reason,
-        # piping env to awk does not work as one might expect for options that are to be lists in config.json.
-        # The following demonstrates setting "searchAttributes" for this container:
-        #    If the following is defined in the container .env file:
-        #       LDAPAUTH_SEARCHATTRIBUTES=["uid","memberOf"]
-        #    then the value written to config.json will be
-        #       "searchAttributes": ["uid", "memberOf"]
+        # Override quote for list/array options.
+        # Example for setting searchAttributes: 
+        # If the following is defined in the container .env file:
+        #    LDAPAUTH_SEARCHATTRIBUTES=["uid","memberOf"]
+        # then the value written to config.json will be
+        #    "searchAttributes": ["uid", "memberOf"]
         quote["searchAttributes"] = "";
 
         # Set defaults.

--- a/setconfig
+++ b/setconfig
@@ -112,7 +112,8 @@ env | awk '
             print "    " q var q ": " vq def[var] vq ",";
         }
     }'
-echo '    "enabled": true'
+echo '    "enabled": true,'
+echo '    "searchAttributes": ["mail", "displayName", "memberOf"]'
 if [ "X${CLIENT_ID}" = X ] ; then
     echo '  }'
 else
@@ -135,7 +136,8 @@ sed -e "s/CLIENT_ID/${CLIENT_ID}/" \
                 "base64": SECRET_BASE64,
                 "timeout": JWT_TIMEOUT,
                 "timeout_units": "JWT_TIMEOUT_UNITS"
-	}
+	},
+	"debug": true
 HERE
 fi
 

--- a/setconfig
+++ b/setconfig
@@ -92,11 +92,23 @@ env | awk '
         quote["queueTimeout"] = "";
         quote["queueDisable"] = "";
 
+        # Override quote for list/array options also.
+        # Note: Docker does not send array-type environment variables as arrays. For this reason,
+        # piping env to awk does not work as one might expect for options that are to be lists in config.json.
+        # The following demonstrates setting "searchAttributes" for this container:
+        #    If the following is defined in the container .env file:
+        #       LDAPAUTH_SEARCHATTRIBUTES=["uid","memberOf"]
+        #    then the value written to config.json will be
+        #       "searchAttributes": ["uid", "memberOf"]
+        quote["searchAttributes"] = "";
+
         # Set defaults.
         def["timeout"] = "5000";
         def["connectTimeout"] = "10000";
         def["reconnect"] = "true";
         def["searchFilter"] = "(CN={{username}})";
+        def["searchAttributes"] = "[\"uid\", \"mail\", \"displayName\", \"memberOf\"]";
+
     }
     /^LDAPAUTH_/ {
         var=tolower($0); sub(/=.*/,"",var); sub(/ldapauth_/,"",var);

--- a/setconfig
+++ b/setconfig
@@ -112,8 +112,7 @@ env | awk '
             print "    " q var q ": " vq def[var] vq ",";
         }
     }'
-echo '    "enabled": true,'
-echo '    "searchAttributes": ["mail", "displayName", "memberOf"]'
+echo '    "enabled": true'
 if [ "X${CLIENT_ID}" = X ] ; then
     echo '  }'
 else
@@ -136,8 +135,7 @@ sed -e "s/CLIENT_ID/${CLIENT_ID}/" \
                 "base64": SECRET_BASE64,
                 "timeout": JWT_TIMEOUT,
                 "timeout_units": "JWT_TIMEOUT_UNITS"
-	},
-	"debug": true
+	}
 HERE
 fi
 


### PR DESCRIPTION
This pull request adds optional functionality to allow authentication for a specific user groups from LDAP via 'memberOf'.

**Example usage for authentication**

POST request to /authenticate:

```
{
  "username": <username>,
  "password": <password>,
  "authorized_groups": [ <LDAP group1>, <LDAP group2> ] <-- this is the new optional key/value pair
}
```

User will be authenticated only if they are a 'memberOf' one of the specified LDAP groups. The keys returned in the JWT payload will include a new 'user_authorized_groups', which is the intersection of the user's groups and the authorized_groups list.

So in this example, if the user is only in LDAP group2, the JWT payload would be:

```
{
    "aud": <client id>,
    "user_authorized_groups": [ <LDAP group2> ]  <-- new optional key/value pair
    "exp": <expiry date>,
    "full_name": <displayName>,
    "mail": <email>,
    "user_name": <username>
}
```

**Example usage for verification**

Similarly, requests to /verify that include an authorized_group,

```
{
  "token": <JWT>,
  "authorized_groups": [ <LDAP group1>, <LDAP group2> ] <-- new optional key/value pair
}
```

will be verified only if the token contains a user_authorized_groups list that includes at least one of the authorized_groups. 

For either endpoint, if no authorized_group is included the the POST request, the behavior is unchanged.

