### PR TITLE
Add authorized group option

### DIFF
--- a/setconfig
+++ b/setconfig
@@ -92,11 +92,21 @@ env | awk '
         quote["queueTimeout"] = "";
         quote["queueDisable"] = "";
 
+        # Override quote for list/array options.
+        # Example for setting searchAttributes: 
+        # If the following is defined in the container .env file:
+        #    LDAPAUTH_SEARCHATTRIBUTES=["uid","memberOf"]
+        # then the value written to config.json will be
+        #    "searchAttributes": ["uid", "memberOf"]
+        quote["searchAttributes"] = "";
+
         # Set defaults.
         def["timeout"] = "5000";
         def["connectTimeout"] = "10000";
         def["reconnect"] = "true";
         def["searchFilter"] = "(CN={{username}})";
+        def["searchAttributes"] = "[\"uid\", \"mail\", \"displayName\", \"memberOf\"]";
+
     }
     /^LDAPAUTH_/ {
         var=tolower($0); sub(/=.*/,"",var); sub(/ldapauth_/,"",var);


### PR DESCRIPTION
This pull request adds optional functionality to allow authentication for a specific user groups from LDAP via 'memberOf'.

**Example usage for authentication**

POST request to /ldap-jtw/authenticate:

```
{
  "username": <username>,
  "password": <password>,
  "authorized_groups": [ <LDAP group1>, <LDAP group2> ] <-- this is the new optional key/value pair
}
```

User will be authenticated only if they are a 'memberOf' one of the specified LDAP groups. The keys returned in the JWT payload will include a new 'user_authorized_groups', which is the intersection of the user's groups and the authorized_groups list.

So in this example, if the user is only in LDAP group2, the JWT payload would be:

```
{
    "aud": <client id>,
    "user_authorized_groups": [ <LDAP group2> ]  <-- new optional key/value pair
    "exp": <expiry date>,
    "full_name": <displayName>,
    "mail": <email>,
    "user_name": <username>
}
```

**Example usage for verification**

Similarly, requests to /ldap-jwt/verify that include an authorized_group,

```
{
  "token": <JWT>,
  "authorized_groups": [ <LDAP group1>, <LDAP group2> ] <-- new optional key/value pair
}
```

will be verified only if the token contains a user_authorized_groups list that includes at least one of the authorized_groups.

For either endpoint, if no authorized_group is included the the POST request, the behavior is unchanged.

Note: this PR is essentially the same as the closed, un-merged #1 , but that PR was to a master branch that did not yet have SSL available.  