### PR TITLE
Make SSL optional 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #   docker build -t ldap-jwt .
 #   docker run -p 3000:3000 --rm -it --env-file config.txt ldap-jwt
 
-FROM node:7.10.0
+FROM node:17.4.0
 
 ENV LDAPJWT_BASE_DIR="/usr/src/app"
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -10,21 +10,17 @@ Heavily based on the work of [gregfroese/ldapservice](https://github.com/gregfro
 * Removed support for RabbitMQ
 * Updated npm dependencies
 * Simplified endpoints
-* Added SSL 
+* Added option to use SSL (httpS) 
 
 
 ## Usage
 
-#### 1. SSL Certificates
 
-Generate / obtain SSL certificates, and place the .crt and .key files in an
-'ssl' directory at the top-level of the directory: ssl/server.key and ssl/server.crt
-
-#### 2. Configuration variables
+#### 1. Configuration variables
 
 Place configuration variables in .env file. Example:
 
-```
+```bash
 LDAP=enabled
 LDAPAUTH_URL=ldaps://hostname
 LDAPAUTH_BINDCREDENTIALS=secret
@@ -32,8 +28,14 @@ LDAPAUTH_SEARCHBASE=dc=example,dc=com
 LDAPAUTH_BINDDN=cn=bind_user,dc=examle,dc=com
 CLIENT_ID=test-client-id
 CLIENT_SECRET=test-client-secret
-DEBUG=true
+DEBUG=true  ## <-- turns on debugging
+SSL=true ## <-- turns on SSL (httpS)
 ```
+
+#### 2. SSL Certificates
+
+If setting SSL=true, generate / obtain SSL certificates, and place the .crt and .key files in an 'ssl' directory at the top-level of the directory: ssl/server.key and ssl/server.crt
+
 
 #### 3. Build image
 

--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ if (settings.ssl) {
 		});
 	});
 } else {
-	console.warn("WARNING: Server configured for http (not httpS), and is therefore suitable for development only.");
+	console.warn("WARNING: Server configured for http (not httpS).");
 	var server = http.createServer(app).listen(port,function(){
 		console.log("Express server listenting on port " + port + " using http");
 			app.on("error",(err) => {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ var fs = require('fs'),
 
 if (settings.ssl) {
 	var https = require('https');
+	if (!fs.existsSync("./ssl/server.key") || !fs.existsSync("./ssl/server.crt")) {
+		console.error("FATAL: missing required SSL certificates. Exiting.");
+		process.exit(1);
+	}
 } else {
 	var http = require('http');
 }
@@ -210,10 +214,6 @@ var port = (process.env.PORT || 3000);
 
 
 if (settings.ssl) {
-	if (!fs.existsSync("./ssl/server.key") || !fs.existsSync("./ssl/server.crt")) {
-		console.error("FATAL: missing required SSL certificates. Exiting.");
-		process.exit(1);
-	}
 	var options = {
 	    key:  fs.readFileSync("./ssl/server.key"),
 	    cert: fs.readFileSync("./ssl/server.crt"),

--- a/index.js
+++ b/index.js
@@ -13,9 +13,13 @@ var moment = require('moment');
 var LdapAuth = require('ldapauth-fork');
 var Promise  = require('promise');
 var fs = require('fs'),
-    https = require('https'),
     express = require('express');
 
+if (settings.ssl) {
+	var https = require('https');
+} else {
+	var http = require('http');
+}
 
 app = require('express')();
 
@@ -205,15 +209,26 @@ let userGroupAuthGroupIntersection = function(userGroups, authorized_groups) {
 var port = (process.env.PORT || 3000);
 
 
-var options = {
-    key:  fs.readFileSync("./ssl/server.key"),
-    cert: fs.readFileSync("./ssl/server.crt"),
-};
-var server = https.createServer(options,app).listen(port,function(){
-	console.log("Express server listenting on port " + port);
-		app.on("error",(err) => {
-		console.warn("ERROR: "+err.stack);
+if (settings.ssl) {
+	var options = {
+	    key:  fs.readFileSync("./ssl/server.key"),
+	    cert: fs.readFileSync("./ssl/server.crt"),
+	};
+	var server = https.createServer(options,app).listen(port,function(){
+		console.log("Express server listenting on port " + port + " using httpS");
+			app.on("error",(err) => {
+			console.warn("ERROR: "+err.stack);
+		});
 	});
-});
+} else {
+	var server = http.createServer(app).listen(port,function(){
+		console.log("Express server listenting on port " + port + " using http");
+			app.on("error",(err) => {
+			console.warn("ERROR: "+err.stack);
+		});
+	});
+}
+
+
 
 

--- a/index.js
+++ b/index.js
@@ -210,6 +210,10 @@ var port = (process.env.PORT || 3000);
 
 
 if (settings.ssl) {
+	if (!fs.existsSync("./ssl/server.key") || !fs.existsSync("./ssl/server.crt")) {
+		console.error("FATAL: missing required SSL certificates. Exiting.");
+		process.exit(1);
+	}
 	var options = {
 	    key:  fs.readFileSync("./ssl/server.key"),
 	    cert: fs.readFileSync("./ssl/server.crt"),

--- a/index.js
+++ b/index.js
@@ -221,6 +221,7 @@ if (settings.ssl) {
 		});
 	});
 } else {
+	console.warn("WARNING: Server configured for http (not httpS), and is therefore suitable for development only.");
 	var server = http.createServer(app).listen(port,function(){
 		console.log("Express server listenting on port " + port + " using http");
 			app.on("error",(err) => {

--- a/setconfig
+++ b/setconfig
@@ -149,13 +149,19 @@ sed -e "s/CLIENT_ID/${CLIENT_ID}/" \
 HERE
 fi
 
-# Debug
+# If env DEBUG defined, turn on debugging
 if [ "X${DEBUG}" != X ] ; then
 >&2 echo DEBUG is enabled
  echo ' ,
 	"debug": "true"'
 fi
 
+# If env SSL defined, use SSL
+if [ "X${SSL}" != X ] ; then
+>&2 echo Using SSL
+ echo ' ,
+	"ssl": "true"'
+fi
 
 echo "}"
 


### PR DESCRIPTION
Pull request #2 added SSL, i.e. httpS. As a result, even for initial testing and development, certificates must be managed. It's annoying to have that barrier to initial exploration of the code.

This pull request makes SSL optional and configurable via an environment variable with usage similar to the DEBUG flag. The default is for SSL to be OFF.

Additional change: node was updated from 7.10.0 to 17.4.0. As of 10 Feb 2022, node:17.4.0 is a supported tag on Docker hub.

