### PR TITLE
Make LDAP search filter configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Place configuration variables in .env file. Below is an example:
 
 ```bash
 LDAP=enabled
+LDAP_SEARCHFILTER=(cn={{username}})
 LDAPAUTH_URL=ldaps://hostname
 LDAPAUTH_SEARCHBASE=dc=example,dc=com
 ## If LDAPAUTH_BINDDN and LDAPAUTH_BINDCREDENTIALS are given,

--- a/README.md
+++ b/README.md
@@ -209,3 +209,15 @@ In this example, the JWT payload contains an encoded authorized\_groups key with
 ```
 
 In the response, the user\_authorized\_groups list is the intersection of the "authorized_groups" in the original request made to generate the token and the user's groups in LDAP.
+
+### /ldap-jwt/health
+
+A 'health check' endpoint that accepts GET requests and returns a 200 status and JSON message if the server is running.
+
+*Response:*
+
+```
+{
+  "message": "OK"
+}
+```

--- a/app/logger.js
+++ b/app/logger.js
@@ -1,6 +1,6 @@
 const bunyan = require('bunyan');
 const bformat = require('bunyan-format');
-const formatOut = bformat({ outputMode: 'short', color: true });
+const formatOut = bformat({ outputMode: 'long', color: true });
 
 const logger = bunyan.createLogger({ // also used for logging in ldapauth-fork and ldapjs
 	name: 'ldap-jwt',

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldap-jwt",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Lightweight node.js based web service that provides user authentication against LDAP server (Active Directory / Windows network) credentials and returns a JSON Web Token.",
   "main": "index.js",
   "scripts": {

--- a/app/setconfig
+++ b/app/setconfig
@@ -61,8 +61,8 @@ if [ "X${LDAP}" = Xenabled ] ; then
     error=1
   fi
   if [ -z "${LDAP_SEARCHFILTER}" ] ; then
-    >&2 echo Error: LDAP is enabled, but LDAP_SEARCHFILTER is not defined
-    error=1
+    >&2 echo WARNING: LDAP is enabled, but LDAP_SEARCHFILTER is not defined. Using default: '(CN={{username}})'
+    export LDAP_SEARCHFILTER="(CN={{username}})"
   fi
   if [ "X${CLIENT_ID}" = X ] ; then
     >&2 echo Error: LDAP is enabled, but CLIENT_ID is not defined

--- a/app/setconfig
+++ b/app/setconfig
@@ -55,10 +55,13 @@ if [ "X${LDAP}" = Xenabled ] ; then
     >&2 echo Error: LDAPAUTH_BINDDN_SUFFIX is defined but LDAPAUTH_BINDDN_PREFIX is not.
     exit 0
   fi
-  ## Check for conflicting configurations.
 
   if [ -z "${LDAPAUTH_SEARCHBASE}" ] ; then
     >&2 echo Error: LDAP is enabled, but LDAPAUTH_SEARCHBASE is not defined
+    error=1
+  fi
+  if [ -z "${LDAP_SEARCHFILTER}" ] ; then
+    >&2 echo Error: LDAP is enabled, but LDAP_SEARCHFILTER is not defined
     error=1
   fi
   if [ "X${CLIENT_ID}" = X ] ; then
@@ -146,7 +149,7 @@ if [ "X${LDAP}" = Xenabled ] ; then
         def["timeout"] = "5000";
         def["connectTimeout"] = "10000";
         def["reconnect"] = "true";
-        def["searchFilter"] = "(CN={{username}})";
+        def["searchFilter"] = "'${LDAP_SEARCHFILTER}'";
         def["searchAttributes"] = "[\"uid\", \"mail\", \"displayName\", \"memberOf\"]";
 
     }

--- a/app/setconfig
+++ b/app/setconfig
@@ -205,7 +205,7 @@ echo "}"
 
 if [ "${BUILD_TARGET}" == "dev" ] ; then
   echo "Wrote file: config.json for DEVELOPMENT build."
-  echo "Starting server for deveopment (requires devDependency nodemon)"
+  echo "Starting server for development (requires devDependency nodemon)"
   exec npm run devstart
 elif [ "${BUILD_TARGET}" == "ci" ] ; then
   echo "Wrote file: config.json for CI build. Exiting"

--- a/app/utils.js
+++ b/app/utils.js
@@ -267,6 +267,7 @@ let bind = async function (username, password, settings) {
 			if (settings.ldap.bindAsUser) {
 				settingsForBind.bindCredentials = password;
 				settingsForBind.bindDn = settings.ldap.binddn_prefix + username + settings.ldap.binddn_suffix;
+				logger.debug("Binding info: " + JSON.stringify(settingsForBind, hideSecretsAndLogger, 4));
 			} else {
 				settingsForBind.bindCredentials = settings.ldap.bindCredentials;
 				settingsForBind.bindDn = settings.ldap.bindDn;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - JWT_TIMEOUT=${JWT_TIMEOUT:-2}
       - JWT_TIMEOUT_UNITS=${JWT_TIMEOUT_UNITS:-days}
       - LDAP=${LDAP:-enabled}
+      - LDAP_SEARCHFILTER
       # Uncomment these (and comment out LDAPAUTH_BINDDN_PREFIX and LDAPAUTH_BINDDN_SUFFIX)
       # to use service accout to bind to LDAP
       #- LDAPAUTH_BINDCREDENTIALS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         PORT: ${PORT:-3000}
     image: ${IMAGE:-ldap-jwt}:${TAG:-latest}
     container_name: ldap-jwt
+    restart: always
     environment:
       - BASE_URL_PATH=${BASE_URL_PATH:-ldap-jwt} # Base path for URL
       - BUILD_TARGET=${BUILD_TARGET:-prod} # used in Dockerfile and setconfig


### PR DESCRIPTION
In version 1.3.0, we added the ability to use the authenticating user to bind to LDAP, and allowed for an optional prefix and suffix to the username for binding (LDAP_BINDDN_PREFIX, LDAP_BINDDN_SUFFIX). This allowed, for example, binding via the authenticating user's email address by setting:

```
LDAP_BINDDN_PREFIX=""
LDAP_BINDDN_SUFFIX="@example.com"
```

However, the LDAP search filter in setconfig was hard-coded to "(CN={{username}})". This created a potential mismatch if the user's common name (CN) was different from the name in their email address (e.g. CN=user, but with email address "user1@<span></span>example.com").

This PR addresses the potential mismatch by adding a new environment variable: `LDAP_SEARCHFILTER`. In the example described above, setting this variable as:

```bash
LDAP_SEARCHFILTER=(mail={{username}}@example.com)
```

resolves the potential mismatch by removing any reference to the CN.

In order to avoid making this PR into a breaking change, if no LDAP_SEARCHFILTER env is provided, a warning message is printed by setconfig, and a default value, (CN={{username}}), is set. (There is no way to escape curly braces in docker-compose.yml file, otherwise I'd have put the default there).

In addition a few other minor issues have been addressed:

- Added health check info to README (#19)
- Added date to server log timestamps (#21)
  - Bunyan logger does not have timezone support, so logs are still in UTC
- Set restart policy to always
- Updated version number: 1.3.0 -> 1.3.1 

