### PR TITLE
Allow for binding with DN

### DIFF
--- a/app/__tests__/mock-ldap.js
+++ b/app/__tests__/mock-ldap.js
@@ -38,6 +38,18 @@ const users = [
       mail: 'user2@example',
       displayName: 'User Two'
     }
+  },
+  {
+    dn: 'cn=bothelper,dc=service,dc=example,dc=com', /* no email for service account */
+    attributes: {
+      objectClass: 'person',
+      cn: 'bothelper',
+      memberOf: [
+        'cn=bots,dc=group,dc=example,dc=com',
+      ],
+      uid: 'bothelper',
+      displayName: 'Bot Helper'
+    }
   }
 ];
 const serverConfiguration = {

--- a/app/__tests__/route_tests.js
+++ b/app/__tests__/route_tests.js
@@ -30,6 +30,19 @@ describe('Testing /health, /authenticate, and /verify endpoints', () => {
     expect(res.statusCode).toEqual(200); // valid token, so verify should pass
   });
 
+  test('valid user no groups, using distinguished name', async() => {
+    let res = await request(app).post(baseUrlPath + '/authenticate').send({
+      username: 'cn=user1,dc=example,dc=com',
+      password: 'password1'
+    });
+    expect(res.statusCode).toEqual(200); // valid user, so authenticate should pass
+    let token = res.body.token;
+    res = await request(app).post(baseUrlPath + '/verify').send({
+      token: token
+    });
+    expect(res.statusCode).toEqual(200); // valid token, so verify should pass
+  });
+
   test('invalid user', async() => {
     let res = await request(app).post(baseUrlPath + '/authenticate').send({
       username: 'user-not-in-database',

--- a/app/index.js
+++ b/app/index.js
@@ -1,134 +1,144 @@
-var settings = require('./config/config.json');
-const ut = require('./utils');
-const logger = require('./logger');
+var settings = require("./config/config.json");
+const ut = require("./utils");
+const logger = require("./logger");
 
-logger.debug("Node version: "+process.version);
+logger.debug("Node version: " + process.version);
 logger.debug("Settings: " + JSON.stringify(settings, ut.hideSecretsAndLogger, 2));
 
-var bodyParser = require('body-parser');
-var fs = require('fs')
+var bodyParser = require("body-parser");
+var fs = require("fs");
 
 if (settings.ssl) {
-	var https = require('https');
-	if (!fs.existsSync("./ssl/server.key") || !fs.existsSync("./ssl/server.crt")) {
-		logger.error("Missing required SSL certificates. Exiting.");
-		process.exit(1);
-	}
+  var https = require("https");
+  if (!fs.existsSync("./ssl/server.key") || !fs.existsSync("./ssl/server.crt")) {
+    logger.error("Missing required SSL certificates. Exiting.");
+    process.exit(1);
+  }
 } else {
-	var http = require('http');
+  var http = require("http");
 }
 
 if (process.env.BASE_URL_PATH === undefined) {
-	logger.warn("BASE_URL_PATH environment variable not set. Using default 'ldap-jwt'.");
-	process.env.BASE_URL_PATH = "ldap-jwt";
+  logger.warn("BASE_URL_PATH environment variable not set. Using default 'ldap-jwt'.");
+  process.env.BASE_URL_PATH = "ldap-jwt";
 }
 const baseUrlPath = "/" + process.env.BASE_URL_PATH;
 
-app = require('express')();
+app = require("express")();
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use(require('cors')());
+app.use(require("cors")());
 
-if (settings.hasOwnProperty( 'ldap' ) && settings.hasOwnProperty( 'jwt' )) {
-	if (!settings.ldap.hasOwnProperty('bindDn')) {
-		settings.ldap.bindAsUser = true;
-	}
-	logger.debug("LdapAuth settings: " + JSON.stringify(settings.ldap, ut.hideSecretsAndLogger, 2));
+if (settings.hasOwnProperty("ldap") && settings.hasOwnProperty("jwt")) {
+  if (!settings.ldap.hasOwnProperty("bindDn")) {
+    settings.ldap.bindAsUser = true;
+  }
+  logger.debug("LdapAuth settings: " + JSON.stringify(settings.ldap, ut.hideSecretsAndLogger, 2));
 } else {
-	logger.error("LDAP and JWT settings are required. Exiting.");
-	process.exit(1);
+  logger.error("LDAP and JWT settings are required. Exiting.");
+  process.exit(1);
 }
 
-if (settings.hasOwnProperty( 'jwt' )) {
-	if (!settings.jwt.hasOwnProperty('timeout')) {
-		settings.jwt.timeout = 1;
-		logger.warn("Settings.jwt.timeout not set - using default: " + settings.jwt.timeout);
-	}
-	if (!settings.jwt.hasOwnProperty('timeout_units')) {
-		settings.jwt.timeout_units = 'hour';
-		logger.warn("Settings.jwt.timeout_units not set - using default: " + settings.jwt.timeout_units);
-	}
-	app.set('jwtTokenSecret',
-		settings.jwt.base64 ? new Buffer(settings.jwt.secret, 'base64') : settings.jwt.secret);
+if (settings.hasOwnProperty("jwt")) {
+  if (!settings.jwt.hasOwnProperty("timeout")) {
+    settings.jwt.timeout = 1;
+    logger.warn("Settings.jwt.timeout not set - using default: " + settings.jwt.timeout);
+  }
+  if (!settings.jwt.hasOwnProperty("timeout_units")) {
+    settings.jwt.timeout_units = "hour";
+    logger.warn(
+      "Settings.jwt.timeout_units not set - using default: " + settings.jwt.timeout_units
+    );
+  }
+  app.set(
+    "jwtTokenSecret",
+    settings.jwt.base64 ? new Buffer(settings.jwt.secret, "base64") : settings.jwt.secret
+  );
 }
 
-app.post(baseUrlPath + '/authenticate', function (req, res) {
-	if(!req.body.username || !req.body.password) {
-		logger.warn("No username or password supplied in request");
-		res.status(400).send({error: 'No username or password supplied'});
-		return false;
-	}
-	ut.authenticateHandler(req.body.username, req.body.password, settings, req.body.authorized_groups)
-		.then(function (authResponse) {
-			res.status(authResponse.httpStatus).send({
-				token: authResponse.token,
-				full_name: authResponse.full_name,
-				mail: authResponse.mail
-			});
-		})
-		.catch(function (err) {
-			res.status(err.httpStatus).send({error: err.message});
-		});
+app.post(baseUrlPath + "/authenticate", function (req, res) {
+  if (!req.body.username || !req.body.password) {
+    logger.warn("No username or password supplied in request");
+    res.status(400).send({ error: "No username or password supplied" });
+    return false;
+  }
+  ut.authenticateHandler(req.body.username, req.body.password, settings, req.body.authorized_groups)
+    .then(function (authResponse) {
+      res.status(authResponse.httpStatus).send({
+        token: authResponse.token,
+        full_name: authResponse.full_name,
+        mail: authResponse.mail
+      });
+    })
+    .catch(function (err) {
+      res.status(err.httpStatus).send({ error: err.message });
+    });
 });
 
-app.post(baseUrlPath + '/verify', function (req, res) {
-	if (!req.body.token) {
-		logger.warn("No token supplied in request");
-		res.status(400).send({error: 'No token supplied'});
-		return false;
-	}
-	if (!settings.hasOwnProperty( 'jwt' )) {
-		logger.error("JWT settings not found!");
-		res.status(500).send({error: 'Server error'});
-		return false;
-	}
-	let validation = ut.verifyHandler(req.body.token, req.body.authorized_groups);
-	if (validation.httpStatus == 200) {
-		res.status(200).send(validation.decodedToken);
-	} else {
-		res.status(validation.httpStatus).send({error: validation.message});
-	}
+app.post(baseUrlPath + "/verify", function (req, res) {
+  if (!req.body.token) {
+    logger.warn("No token supplied in request");
+    res.status(400).send({ error: "No token supplied" });
+    return false;
+  }
+  if (!settings.hasOwnProperty("jwt")) {
+    logger.error("JWT settings not found!");
+    res.status(500).send({ error: "Server error" });
+    return false;
+  }
+  let validation = ut.verifyHandler(req.body.token, req.body.authorized_groups);
+  if (validation.httpStatus == 200) {
+    res.status(200).send(validation.decodedToken);
+  } else {
+    res.status(validation.httpStatus).send({ error: validation.message });
+  }
 });
 
-app.get(baseUrlPath + '/health', function (req, res) {
-	res.status(200).send({message: 'OK'});
+app.get(baseUrlPath + "/health", function (req, res) {
+  res.status(200).send({ message: "OK" });
 });
 
-var port = (process.env.PORT || 3000);
+var port = process.env.PORT || 3000;
 
-if (settings.ssl) { // use httpS
-	var options = {
-	    key:  fs.readFileSync("./ssl/server.key"),
-	    cert: fs.readFileSync("./ssl/server.crt"),
-	};
-	var server = https.createServer(options,app).listen(port,function(){
-		logger.info("Server running. Base URL: https://localhost:" + port + baseUrlPath);
-		logger.info('JWT tokens will expire after ' + settings.jwt.timeout + ' ' + settings.jwt.timeout_units);
-		logger.info("LDAP URL: " + settings.ldap.url);
-		if (settings.ldap.bindAsUser) {
-			logger.info("Will bind with authenticating user's credentials");
-		} else {
-			logger.info("Will bind with service account: " + ut.getGroupCN(settings.ldap.bindDn));
-		}
-		app.on("error",(err) => {
-			logger.error("ERROR: " + err.stack);
-		});
-	});
-} else { // use http
-	var server = http.createServer(app).listen(port,function(){
-		logger.info("Server running. Base URL: http://localhost:" + port + baseUrlPath);
-		logger.info('JWT tokens will expire after ' + settings.jwt.timeout + ' ' + settings.jwt.timeout_units);
-		logger.info("LDAP URL: " + settings.ldap.url);
-		if (settings.ldap.bindAsUser) {
-			logger.info("Will bind with authenticating user's credentials");
-		} else {
-			logger.info("Will bind with service account: " + settings.ldap.bindDn);
-		}
-		logger.warn("Server configured for http (not httpS).");
-		app.on("error",(err) => {
-			logger.error("ERROR: " + err.stack);
-		});
-	});
+if (settings.ssl) {
+  // use httpS
+  var options = {
+    key: fs.readFileSync("./ssl/server.key"),
+    cert: fs.readFileSync("./ssl/server.crt")
+  };
+  var server = https.createServer(options, app).listen(port, function () {
+    logger.info("Server running. Base URL: https://localhost:" + port + baseUrlPath);
+    logger.info(
+      "JWT tokens will expire after " + settings.jwt.timeout + " " + settings.jwt.timeout_units
+    );
+    logger.info("LDAP URL: " + settings.ldap.url);
+    if (settings.ldap.bindAsUser) {
+      logger.info("Will bind with authenticating user's credentials");
+    } else {
+      logger.info("Will bind with service account: " + ut.getGroupCN(settings.ldap.bindDn));
+    }
+    app.on("error", (err) => {
+      logger.error("ERROR: " + err.stack);
+    });
+  });
+} else {
+  // use http
+  var server = http.createServer(app).listen(port, function () {
+    logger.info("Server running. Base URL: http://localhost:" + port + baseUrlPath);
+    logger.info(
+      "JWT tokens will expire after " + settings.jwt.timeout + " " + settings.jwt.timeout_units
+    );
+    logger.info("LDAP URL: " + settings.ldap.url);
+    if (settings.ldap.bindAsUser) {
+      logger.info("Will bind with authenticating user's credentials");
+    } else {
+      logger.info("Will bind with service account: " + settings.ldap.bindDn);
+    }
+    logger.warn("Server configured for http (not httpS).");
+    app.on("error", (err) => {
+      logger.error("ERROR: " + err.stack);
+    });
+  });
 }
 
 // export server for testing

--- a/app/index.js
+++ b/app/index.js
@@ -100,8 +100,7 @@ app.get(baseUrlPath + "/health", function (req, res) {
 
 var port = process.env.PORT || 3000;
 
-if (settings.ssl) {
-  // use httpS
+if (settings.ssl) { // use httpS
   var options = {
     key: fs.readFileSync("./ssl/server.key"),
     cert: fs.readFileSync("./ssl/server.crt")
@@ -121,8 +120,7 @@ if (settings.ssl) {
       logger.error("ERROR: " + err.stack);
     });
   });
-} else {
-  // use http
+} else { // use http
   var server = http.createServer(app).listen(port, function () {
     logger.info("Server running. Base URL: http://localhost:" + port + baseUrlPath);
     logger.info(

--- a/app/logger.js
+++ b/app/logger.js
@@ -2,8 +2,7 @@ const bunyan = require("bunyan");
 const bformat = require("bunyan-format");
 const formatOut = bformat({ outputMode: "long", color: process.env.COLORIZE_LOGS?.toLowerCase() === "true" });
 
-const logger = bunyan.createLogger({
-  // also used for logging in ldapauth-fork and ldapjs
+const logger = bunyan.createLogger({ // bunyan is also used for logging in ldapauth-fork and ldapjs
   name: "ldap-jwt",
   level: process.env.LOG_LEVEL || "info",
   stream: formatOut

--- a/app/logger.js
+++ b/app/logger.js
@@ -1,13 +1,12 @@
-const bunyan = require('bunyan');
-const bformat = require('bunyan-format');
-const formatOut = bformat({ outputMode: 'long', color: true });
+const bunyan = require("bunyan");
+const bformat = require("bunyan-format");
+const formatOut = bformat({ outputMode: "long", color: true });
 
-const logger = bunyan.createLogger({ // also used for logging in ldapauth-fork and ldapjs
-	name: 'ldap-jwt',
-	level: (process.env.LOG_LEVEL || 'info'),
-	stream: formatOut
+const logger = bunyan.createLogger({
+  // also used for logging in ldapauth-fork and ldapjs
+  name: "ldap-jwt",
+  level: process.env.LOG_LEVEL || "info",
+  stream: formatOut
 });
 
 module.exports = logger;
-
-

--- a/app/logger.js
+++ b/app/logger.js
@@ -1,6 +1,6 @@
 const bunyan = require("bunyan");
 const bformat = require("bunyan-format");
-const formatOut = bformat({ outputMode: "long", color: true });
+const formatOut = bformat({ outputMode: "long", color: process.env.COLORIZE_LOGS?.toLowerCase() === "true" });
 
 const logger = bunyan.createLogger({
   // also used for logging in ldapauth-fork and ldapjs

--- a/app/utils.js
+++ b/app/utils.js
@@ -27,9 +27,11 @@ async function authenticateHandler(username, password, settings, authorized_grou
       ) {
         logger.warn("InvalidCredentialsError for '" + username + "'");
         reject({ httpStatus: 401, message: "Wrong username or password" });
+        return;
       } else {
         logger.error("Error from authenticate promise: ", err);
         reject({ httpStatus: 500, message: "Sorry about that! Unexpected Error." });
+        return;
       }
     });
   }
@@ -41,11 +43,13 @@ async function authenticateHandler(username, password, settings, authorized_grou
         if (!user.hasOwnProperty("memberOf")) {
           logger.error("Server not configured for authorized_group verification");
           reject({ httpStatus: 500, message: "Unexpected error. Sorry about that!" });
+          return;
         }
         var userGroupsForPayload = userGroupAuthGroupIntersection(user.memberOf, authorized_groups);
         if (!userInAuthorizedGroups(user.memberOf, authorized_groups)) {
           logger.warn(user.displayName + "' not in '" + getGroupCN(authorized_groups) + "'");
           reject({ httpStatus: 401, message: "User is not authorized" });
+          return;
         }
       }
       let token = generateToken(user, settings, userGroupsForPayload);
@@ -56,11 +60,14 @@ async function authenticateHandler(username, password, settings, authorized_grou
           "Request included authorized_groups, but server not configured for authorized_group verification"
         );
         reject({ httpStatus: 401, message: "User is not authorized" });
+        return;
       } else if (err == "User not in authorized_groups") {
         reject({ httpStatus: 401, message: "User is not authorized" });
+        return;
       } else {
         logger.error("Error from authenticate promise: ", err);
         reject({ httpStatus: 500, message: "Unexpected Error. Sorry about that!" });
+        return;
       }
     }
   });
@@ -196,9 +203,11 @@ async function queryAuthentication(username, password, settings) {
       if (err) {
         logger.warn("Authentication error: ", err);
         reject(err);
+        return;
       } else if (!user) {
         logger.debug("ERROR: Reject because no user");
         reject();
+        return;
       } else {
         resolve(user);
       }
@@ -324,6 +333,7 @@ let bind = async function (username, password, settings) {
     } catch (err) {
       logger.error("Error creating new bind: ", err);
       reject();
+      return;
     }
   });
 };
@@ -345,6 +355,7 @@ let unbind = async function (auth, settings) {
     } catch (err) {
       logger.error("Error unbinding: ", err);
       reject();
+      return;
     }
   });
 };

--- a/app/utils.js
+++ b/app/utils.js
@@ -97,27 +97,13 @@ function verifyHandler(token, authorized_groups) {
       return { httpStatus: 400, message: "Access token has expired" };
     } else if (authorized_groups != undefined) {
       if (groupsInToken && userInAuthorizedGroups(groupsInToken, authorized_groups)) {
-        logger.info(
-          "Token valid for '" +
-            usernameInToken +
-            "', " +
-            "requested groups: '" +
-            getGroupCN(authorized_groups) +
-            "', token groups: '" +
-            getGroupCN(groupsInToken) +
-            "'"
-        );
+        logger.info("Token valid for '" + usernameInToken + "', " + "requested groups: '" + getGroupCN(authorized_groups)
+            + "', token groups: '" + getGroupCN(groupsInToken) + "'");
         return { httpStatus: 200, decodedToken: decodedToken };
       } else {
-        logger.warn(
-          "Invalid token: token/authorized group mismatch for user '" +
-            usernameInToken +
-            "', requested groups: '" +
-            getGroupCN(authorized_groups) +
-            "', token groups: '" +
-            getGroupCN(groupsInToken) +
-            "'"
-        );
+        logger.warn("Invalid token: token/authorized group mismatch for user '" +
+            usernameInToken + "', requested groups: '" + getGroupCN(authorized_groups) +
+            "', token groups: '" + getGroupCN(groupsInToken) + "'");
         return { httpStatus: 401, message: "User is not authorized" };
       }
     } else {
@@ -243,23 +229,12 @@ let generateToken = function (user, settings, userGroupsForPayload) {
     }
     let token = jwt.encode(token_json, app.get("jwtTokenSecret"));
     if (userGroupsForPayload != undefined) {
-      logger.info(
-        "Token generated for '" +
-          user.displayName +
-          "' with groups '" +
-          getGroupCN(userGroupsForPayload).join("; ") +
-          "'." +
-          " JWT expires: " +
-          moment(expires).format("MMMM Do YYYY, h:mm:ss a")
-      );
+      logger.info("Token generated for '" + user.displayName + "' with groups '" +
+          getGroupCN(userGroupsForPayload).join("; ") + "'." + " JWT expires: " +
+          moment(expires).format("MMMM Do YYYY, h:mm:ss a"));
     } else {
-      logger.info(
-        "Token generated for '" +
-          user.displayName +
-          "'." +
-          " JWT expires: " +
-          moment(expires).format("MMMM Do YYYY, h:mm:ss a")
-      );
+      logger.info("Token generated for '" + user.displayName + "'." + " JWT expires: " +
+          moment(expires).format("MMMM Do YYYY, h:mm:ss a"));
     }
     return token;
   } catch (err) {

--- a/app/utils.js
+++ b/app/utils.js
@@ -1,7 +1,7 @@
-const logger = require('./logger');
-var LdapAuth = require('ldapauth-fork');
-var moment = require('moment');
-var jwt = require('jwt-simple');
+const logger = require("./logger");
+var LdapAuth = require("ldapauth-fork");
+var moment = require("moment");
+var jwt = require("jwt-simple");
 
 /**
  * Authenticates a user and if user is authenticated, generates a token
@@ -11,54 +11,59 @@ var jwt = require('jwt-simple');
  * @param {string} password - The password of the user.
  * @param {Object} settings - The settings for the authentication.
  * @param {Array} authorized_groups - The groups that are authorized to authenticate.
- * @returns {Promise<Object>} A promise that resolves to an object containing the approriate HTTP response code, 
+ * @returns {Promise<Object>} A promise that resolves to an object containing the approriate HTTP response code,
  * token and user information if the user is authenticated, or rejects with an error message and HTTP status code
  * if the user is not authenticated or an error occurs.
  */
 async function authenticateHandler(username, password, settings, authorized_groups) {
-	// First handle credentials and reject if invalid
-	try {
-		var user = await queryAuthentication(username, password, settings)
-	} catch(err) {
-		return new Promise(function (resolve, reject) {
-			if (err.name === 'InvalidCredentialsError' || (typeof err === 'string' && err.match(/no such user/i)) ) {
-				logger.warn("InvalidCredentialsError for '" + username + "'");
-				reject({httpStatus: 401, message: 'Wrong username or password'});
-			} else {
-				logger.error("Error from authenticate promise: ", err);
-				reject({httpStatus: 500, message: 'Sorry about that! Unexpected Error.'});
-			}
-		})
-	}
-	// Then handle authorized_groups and generate token
-	return new Promise(function (resolve, reject) {
-		try {
-			if (authorized_groups != undefined) {
-				logger.debug("authorized_groups specified: " + authorized_groups);
-				if (!user.hasOwnProperty("memberOf")) {
-					logger.error("Server not configured for authorized_group verification");
-					reject({httpStatus: 500, message: 'Unexpected error. Sorry about that!'});
-				}
-				var userGroupsForPayload = userGroupAuthGroupIntersection(user.memberOf, authorized_groups);
-				if (!userInAuthorizedGroups(user.memberOf, authorized_groups)) {
-					logger.warn(user.displayName + "' not in '" + getGroupCN(authorized_groups) + "'");
-					reject({httpStatus: 401, message: "User is not authorized"});
-				}
-			}
-			let token = generateToken(user, settings, userGroupsForPayload);
-			resolve ({httpStatus: 200, token: token, full_name: user.displayName, mail: user.mail});
-		} catch (err) {
-			if (err == "Server not configured for authorized_group verification") {
-				logger.warn("Request included authorized_groups, but server not configured for authorized_group verification");
-				reject({httpStatus: 401, message: "User is not authorized"});
-			} else if (err == "User not in authorized_groups") {
-				reject({httpStatus: 401, message: "User is not authorized"});
-			} else {
-				logger.error("Error from authenticate promise: ", err);
-				reject({httpStatus: 500, message: 'Unexpected Error. Sorry about that!'});
-			}
-		}
-	})
+  // First handle credentials and reject if invalid
+  try {
+    var user = await queryAuthentication(username, password, settings);
+  } catch (err) {
+    return new Promise(function (resolve, reject) {
+      if (
+        err.name === "InvalidCredentialsError" ||
+        (typeof err === "string" && err.match(/no such user/i))
+      ) {
+        logger.warn("InvalidCredentialsError for '" + username + "'");
+        reject({ httpStatus: 401, message: "Wrong username or password" });
+      } else {
+        logger.error("Error from authenticate promise: ", err);
+        reject({ httpStatus: 500, message: "Sorry about that! Unexpected Error." });
+      }
+    });
+  }
+  // Then handle authorized_groups and generate token
+  return new Promise(function (resolve, reject) {
+    try {
+      if (authorized_groups != undefined) {
+        logger.debug("authorized_groups specified: " + authorized_groups);
+        if (!user.hasOwnProperty("memberOf")) {
+          logger.error("Server not configured for authorized_group verification");
+          reject({ httpStatus: 500, message: "Unexpected error. Sorry about that!" });
+        }
+        var userGroupsForPayload = userGroupAuthGroupIntersection(user.memberOf, authorized_groups);
+        if (!userInAuthorizedGroups(user.memberOf, authorized_groups)) {
+          logger.warn(user.displayName + "' not in '" + getGroupCN(authorized_groups) + "'");
+          reject({ httpStatus: 401, message: "User is not authorized" });
+        }
+      }
+      let token = generateToken(user, settings, userGroupsForPayload);
+      resolve({ httpStatus: 200, token: token, full_name: user.displayName, mail: user.mail });
+    } catch (err) {
+      if (err == "Server not configured for authorized_group verification") {
+        logger.warn(
+          "Request included authorized_groups, but server not configured for authorized_group verification"
+        );
+        reject({ httpStatus: 401, message: "User is not authorized" });
+      } else if (err == "User not in authorized_groups") {
+        reject({ httpStatus: 401, message: "User is not authorized" });
+      } else {
+        logger.error("Error from authenticate promise: ", err);
+        reject({ httpStatus: 500, message: "Unexpected Error. Sorry about that!" });
+      }
+    }
+  });
 }
 /**
  * Verifies a JWT token. If authorized_groups supplied, verfication includes checking if token includes the authorized_groups.
@@ -69,45 +74,58 @@ async function authenticateHandler(username, password, settings, authorized_grou
  * successful or an error message if it was not.
  */
 function verifyHandler(token, authorized_groups) {
-	// first try/catch is for decoding the token
-	try {
-		var decodedToken = jwt.decode(token, app.get('jwtTokenSecret'));
-		var groupsInToken = decodedToken.user_authorized_groups;
-		var usernameInToken = decodedToken.user_name;
-	} catch (err) {
-		logger.warn("Error decoding token: " + err);
-		return({httpStatus: 401, message: 'User is not authorized'});
-	}
-	// second try/catch is for verifying token is valid
-	try {
-		if (decodedToken.exp <= Date.now()) {
-			logger.warn("Verification failed: expired token for '" + usernameInToken + "'");
-			return({httpStatus: 400, message: 'Access token has expired'});
-		} else if (authorized_groups != undefined) {
-			if (groupsInToken && userInAuthorizedGroups(groupsInToken, authorized_groups)) {
-				logger.info("Token valid for '" + usernameInToken + "', " +
-					"requested groups: '" + getGroupCN(authorized_groups) +
-					"', token groups: '" + getGroupCN(groupsInToken) + "'");
-				return({httpStatus: 200, decodedToken: decodedToken});
-			} else {
-				logger.warn("Invalid token: token/authorized group mismatch for user '" +
-					usernameInToken + "', requested groups: '" + getGroupCN(authorized_groups) +
-					"', token groups: '" + getGroupCN(groupsInToken) + "'");
-				return({httpStatus: 401, message: 'User is not authorized'});
-			}
-		} else {
-			logger.info("Token verified for '" + usernameInToken + "'");
-			return({httpStatus: 200, decodedToken: decodedToken});
-		}
-	} catch (err) {
-		logger.warn("Verification failed: " + err);
-		return({httpStatus: 500, message: "Sever error. Unable to validate token"});
-	}
+  // first try/catch is for decoding the token
+  try {
+    var decodedToken = jwt.decode(token, app.get("jwtTokenSecret"));
+    var groupsInToken = decodedToken.user_authorized_groups;
+    var usernameInToken = decodedToken.user_name;
+  } catch (err) {
+    logger.warn("Error decoding token: " + err);
+    return { httpStatus: 401, message: "User is not authorized" };
+  }
+  // second try/catch is for verifying token is valid
+  try {
+    if (decodedToken.exp <= Date.now()) {
+      logger.warn("Verification failed: expired token for '" + usernameInToken + "'");
+      return { httpStatus: 400, message: "Access token has expired" };
+    } else if (authorized_groups != undefined) {
+      if (groupsInToken && userInAuthorizedGroups(groupsInToken, authorized_groups)) {
+        logger.info(
+          "Token valid for '" +
+            usernameInToken +
+            "', " +
+            "requested groups: '" +
+            getGroupCN(authorized_groups) +
+            "', token groups: '" +
+            getGroupCN(groupsInToken) +
+            "'"
+        );
+        return { httpStatus: 200, decodedToken: decodedToken };
+      } else {
+        logger.warn(
+          "Invalid token: token/authorized group mismatch for user '" +
+            usernameInToken +
+            "', requested groups: '" +
+            getGroupCN(authorized_groups) +
+            "', token groups: '" +
+            getGroupCN(groupsInToken) +
+            "'"
+        );
+        return { httpStatus: 401, message: "User is not authorized" };
+      }
+    } else {
+      logger.info("Token verified for '" + usernameInToken + "'");
+      return { httpStatus: 200, decodedToken: decodedToken };
+    }
+  } catch (err) {
+    logger.warn("Verification failed: " + err);
+    return { httpStatus: 500, message: "Sever error. Unable to validate token" };
+  }
 }
 
 /**
  * Replaces sensitive information and logger objects in a given key-value pair with placeholder strings.
- * 
+ *
  * This function was written to bue used as the replacer function for JSON.stringify to avoid logging sensitive
  * data and circular references.
  *
@@ -118,13 +136,13 @@ function verifyHandler(token, authorized_groups) {
  * Otherwise, returns the original value.
  */
 function hideSecretsAndLogger(key, value) {
-	if (key === 'bindCredentials' || key === 'password') {
-		return "********";
-	}
-	if (key === 'log' || key === 'logger') {
-		return "<log object (hidden because it creates circular reference)>";
-	}
-	return value;
+  if (key === "bindCredentials" || key === "password") {
+    return "********";
+  }
+  if (key === "log" || key === "logger") {
+    return "<log object (hidden because it creates circular reference)>";
+  }
+  return value;
 }
 
 /**
@@ -138,21 +156,21 @@ function hideSecretsAndLogger(key, value) {
  * returns the original `groups` value.
  */
 function getGroupCN(groups) {
-	if (groups == undefined) {
-		return undefined;
-	}
-	try {
-		if (typeof groups === 'string') {
-			return groups.split(',')[0].split('=')[1];
-		} else {
-			return groups.map(function (group) {
-				return group.split(',')[0].split('=')[1];
-			})
-		}
-	} catch (e) {
-		logger.error('Error getting CN from "' + groups + '": ' + e);
-		return groups;
-	}
+  if (groups == undefined) {
+    return undefined;
+  }
+  try {
+    if (typeof groups === "string") {
+      return groups.split(",")[0].split("=")[1];
+    } else {
+      return groups.map(function (group) {
+        return group.split(",")[0].split("=")[1];
+      });
+    }
+  } catch (e) {
+    logger.error('Error getting CN from "' + groups + '": ' + e);
+    return groups;
+  }
 }
 
 /**
@@ -167,22 +185,22 @@ function getGroupCN(groups) {
  * or rejects with an error if authentication fails.
  */
 async function queryAuthentication(username, password, settings) {
-	let auth = await bind(username, password, settings);
-	return new Promise(function (resolve, reject) {
-		auth.authenticate(username, password, async function (err, user) {
-			await unbind(auth, settings);
-			if(err) {
-				logger.warn("Authentication error: ", err);
-				reject(err);
-			} else if (!user) {
-				logger.debug("ERROR: Reject because no user");
-				reject();
-			} else {
-				resolve(user);
-			}
-		});
-	});
-};
+  let auth = await bind(username, password, settings);
+  return new Promise(function (resolve, reject) {
+    auth.authenticate(username, password, async function (err, user) {
+      await unbind(auth, settings);
+      if (err) {
+        logger.warn("Authentication error: ", err);
+        reject(err);
+      } else if (!user) {
+        logger.debug("ERROR: Reject because no user");
+        reject();
+      } else {
+        resolve(user);
+      }
+    });
+  });
+}
 
 /**
  * Generates a JWT token for a given user.
@@ -198,33 +216,44 @@ async function queryAuthentication(username, password, settings) {
  * @throws Will throw an error if the token cannot be generated.
  */
 let generateToken = function (user, settings, userGroupsForPayload) {
-	try {
-		let expires = moment().add(settings.jwt.timeout, settings.jwt.timeout_units).valueOf();
-		let token_json = {
-			exp: expires,
-			aud: settings.jwt.clientid,
-			user_name: user.uid,
-			full_name: user.displayName,
-			mail: user.mail
-		}
-		if (userGroupsForPayload != undefined) {
-			token_json.user_authorized_groups = userGroupsForPayload;
-		}
-		let token = jwt.encode(token_json, app.get('jwtTokenSecret'));
-		if (userGroupsForPayload != undefined) {
-			logger.info("Token generated for '" + user.displayName + "' with groups '" +
-				getGroupCN(userGroupsForPayload).join("; ") + "'." +
-				" JWT expires: " + moment(expires).format("MMMM Do YYYY, h:mm:ss a"));
-		} else {
-			logger.info("Token generated for '" + user.displayName + "'." +
-				" JWT expires: " + moment(expires).format("MMMM Do YYYY, h:mm:ss a"));
-		}
-		return token;
-	} catch (err) {
-		logger.error("Error generating token: ", err);
-		throw "Unable to generate token";
-	}
-}
+  try {
+    let expires = moment().add(settings.jwt.timeout, settings.jwt.timeout_units).valueOf();
+    let token_json = {
+      exp: expires,
+      aud: settings.jwt.clientid,
+      user_name: user.uid,
+      full_name: user.displayName,
+      mail: user.mail
+    };
+    if (userGroupsForPayload != undefined) {
+      token_json.user_authorized_groups = userGroupsForPayload;
+    }
+    let token = jwt.encode(token_json, app.get("jwtTokenSecret"));
+    if (userGroupsForPayload != undefined) {
+      logger.info(
+        "Token generated for '" +
+          user.displayName +
+          "' with groups '" +
+          getGroupCN(userGroupsForPayload).join("; ") +
+          "'." +
+          " JWT expires: " +
+          moment(expires).format("MMMM Do YYYY, h:mm:ss a")
+      );
+    } else {
+      logger.info(
+        "Token generated for '" +
+          user.displayName +
+          "'." +
+          " JWT expires: " +
+          moment(expires).format("MMMM Do YYYY, h:mm:ss a")
+      );
+    }
+    return token;
+  } catch (err) {
+    logger.error("Error generating token: ", err);
+    throw "Unable to generate token";
+  }
+};
 
 /**
  * Returns an array that represents the intersection of user groups and authorized groups.
@@ -236,17 +265,17 @@ let generateToken = function (user, settings, userGroupsForPayload) {
  * If either parameter is not an array, it is converted to a single-element array before the intersection is computed.
  * @throws {string} Will throw a string error message if unable to determine the intersection.
  */
-let userGroupAuthGroupIntersection = function(userGroups, authorized_groups) {
-	try {
-		if (!Array.isArray(userGroups)) userGroups = [ userGroups ];
-		if (!Array.isArray(authorized_groups)) authorized_groups = [ authorized_groups ];
-		let userGroupsIntersection = userGroups.filter(group => authorized_groups.includes(group));
-		return userGroupsIntersection;
-	} catch (err) {
-		logger.error("Error in userGroupAuthGroupIntersection: ", err);
-		throw "Unable to determine userGroupsAuthGroupIntersection";
-	}
-}
+let userGroupAuthGroupIntersection = function (userGroups, authorized_groups) {
+  try {
+    if (!Array.isArray(userGroups)) userGroups = [userGroups];
+    if (!Array.isArray(authorized_groups)) authorized_groups = [authorized_groups];
+    let userGroupsIntersection = userGroups.filter((group) => authorized_groups.includes(group));
+    return userGroupsIntersection;
+  } catch (err) {
+    logger.error("Error in userGroupAuthGroupIntersection: ", err);
+    throw "Unable to determine userGroupsAuthGroupIntersection";
+  }
+};
 
 /**
  * Binds a user with given username and password to the LDAP server.
@@ -260,26 +289,27 @@ let userGroupAuthGroupIntersection = function(userGroups, authorized_groups) {
  * if an error occurs during binding.
  */
 let bind = async function (username, password, settings) {
-	return new Promise(function (resolve, reject) {
-		try {
-			let settingsForBind = structuredClone(settings.ldap); // structuredClone to avoid changing the original settings
-			settingsForBind.log = logger; // adding bunyan logger to LdapAuth settings
-			if (settings.ldap.bindAsUser) {
-				settingsForBind.bindCredentials = password;
-				settingsForBind.bindDn = settings.ldap.binddn_prefix + username + settings.ldap.binddn_suffix;
-				logger.debug("Binding info: " + JSON.stringify(settingsForBind, hideSecretsAndLogger, 4));
-			} else {
-				settingsForBind.bindCredentials = settings.ldap.bindCredentials;
-				settingsForBind.bindDn = settings.ldap.bindDn;
-			}
-			let auth = new LdapAuth(settingsForBind);
-			resolve(auth);
-		} catch (err) {
-			logger.error("Error creating new bind: ", err);
-			reject();
-		}
-	})
-}
+  return new Promise(function (resolve, reject) {
+    try {
+      let settingsForBind = structuredClone(settings.ldap); // structuredClone to avoid changing the original settings
+      settingsForBind.log = logger; // adding bunyan logger to LdapAuth settings
+      if (settings.ldap.bindAsUser) {
+        settingsForBind.bindCredentials = password;
+        settingsForBind.bindDn =
+          settings.ldap.binddn_prefix + username + settings.ldap.binddn_suffix;
+        logger.debug("Binding info: " + JSON.stringify(settingsForBind, hideSecretsAndLogger, 4));
+      } else {
+        settingsForBind.bindCredentials = settings.ldap.bindCredentials;
+        settingsForBind.bindDn = settings.ldap.bindDn;
+      }
+      let auth = new LdapAuth(settingsForBind);
+      resolve(auth);
+    } catch (err) {
+      logger.error("Error creating new bind: ", err);
+      reject();
+    }
+  });
+};
 
 /**
  * Unbinds a user from the LDAP server.
@@ -291,16 +321,16 @@ let bind = async function (username, password, settings) {
  * @returns {Promise<void>} A promise that resolves if unbinding is successful, or rejects if an error occurs during unbinding.
  */
 let unbind = async function (auth, settings) {
-	return new Promise(function (resolve, reject) {
-		try {
-			auth.close();
-			resolve();
-		} catch (err) {
-			logger.error("Error unbinding: ", err);
-			reject();
-		}
-	})
-}
+  return new Promise(function (resolve, reject) {
+    try {
+      auth.close();
+      resolve();
+    } catch (err) {
+      logger.error("Error unbinding: ", err);
+      reject();
+    }
+  });
+};
 
 /**
  * Checks if a user is part of any of the authorized groups.
@@ -313,19 +343,19 @@ let unbind = async function (auth, settings) {
  * @returns {boolean} Returns true if the user is part of any of the authorized groups, false otherwise.
  * @throws {string} Throws an error message if an error occurs during the process.
  */
-let userInAuthorizedGroups = function(userGroups, authorized_groups) {
-	try {
-		if (!Array.isArray(userGroups)) userGroups = [ userGroups ];
-		if (!Array.isArray(authorized_groups)) authorized_groups = [ authorized_groups ];
-		return userGroups.some(group => authorized_groups.includes(group));
-	} catch (err) {
-		logger.error("Error in userInAuthorizedGroups: ", err);
-		throw "Unable to determine if user in authorized groups";
-	}
-}
+let userInAuthorizedGroups = function (userGroups, authorized_groups) {
+  try {
+    if (!Array.isArray(userGroups)) userGroups = [userGroups];
+    if (!Array.isArray(authorized_groups)) authorized_groups = [authorized_groups];
+    return userGroups.some((group) => authorized_groups.includes(group));
+  } catch (err) {
+    logger.error("Error in userInAuthorizedGroups: ", err);
+    throw "Unable to determine if user in authorized groups";
+  }
+};
 
 module.exports = {
-	authenticateHandler: authenticateHandler,
-	verifyHandler: verifyHandler,
-	hideSecretsAndLogger: hideSecretsAndLogger
-}
+  authenticateHandler: authenticateHandler,
+  verifyHandler: verifyHandler,
+  hideSecretsAndLogger: hideSecretsAndLogger
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - BUILD_TARGET=${BUILD_TARGET:-prod} # used in Dockerfile and setconfig
       - CLIENT_ID
       - CLIENT_SECRET
+      - COLORIZE_LOGS=${COLORIZE_LOGS:-false} # Boolean for colorizing bunyan logs. See logger.js
       - JWT_TIMEOUT=${JWT_TIMEOUT:-2}
       - JWT_TIMEOUT_UNITS=${JWT_TIMEOUT_UNITS:-days}
       - LDAP=${LDAP:-enabled}


### PR DESCRIPTION
The goal of this PR is to address the feature request to allow for binding with distinguished name (DN) because of use cases where a service account wants to get a token, but does not have an email listed in LDAP. In addition, a few minor issues were addressed

Changes:

- Addressed #24 (e2cb5bf, c0726b1)
- Addressed #23 (d6a563d)
- Addressed #20 (d10f56f)
- Ran [prettier](https://prettier.io) (29a9db6, 515aa04)