### PR TITLE
Release prep for 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.11.1-slim as base
+FROM node:22.12.0-slim as base
 
 ARG PORT=3000
 ARG NODE_UID=1001

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldap-jwt",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Lightweight node.js based web service that provides user authentication against LDAP server (Active Directory / Windows network) credentials and returns a JSON Web Token.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR is for two release preparations:

1. Update Dockerfile base image
   - `node:20.11.1-slim` -> `node:22.12.0-slim`
2. Update package version
   - `1.3.1` -> `1.4.0` (we have added a backwards-compatible feature)